### PR TITLE
Set the width of bio-go-card to 100%

### DIFF
--- a/bio-go-panel.js
+++ b/bio-go-panel.js
@@ -50,6 +50,10 @@ class BioGoPanel extends PolymerElement {
           @apply --layout-horizontal;
           @apply --layout-wrap;
         }
+
+        bio-go-card {
+          width: 100%;
+        }
       </style>
 
       <fieldset>


### PR DESCRIPTION
## Summary of Changes
- [X] Set width of bio-go-card to 100% so that it can extend the whole width of the parent.